### PR TITLE
Implement BlockManager for Different Backends

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1,4 +1,4 @@
-package traefik-regex-block
+package traefik_regex_block
 
 import (
     "net"

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1,0 +1,97 @@
+package traefik_regex_block
+
+import (
+    "net"
+    "time"
+)
+
+// BlockStorage defines the interface for managing IP addresses.
+type BlockStorage interface {
+    IsBlocked(ip net.IP) (bool)
+    Block(ip net.IP, minutes int) (error)
+    UnBlock(ip net.IP) (error)
+}
+
+// ArrayStorage implements BlockStorage using an array.
+type ArrayStorage struct {
+    ipList map[string]time.Time
+}
+
+func (as *ArrayStorage) Block(ip net.IP, minutes int) (error) {
+    now := time.Now()
+    as.ipList[ip.String()] = now.Add(time.Minute * time.Duration(minutes))
+    return nil
+}
+
+func (as *ArrayStorage) IsBlocked(ip net.IP) (bool) {
+    blockTime, ok := as.ipList[ip.String()]
+    if ! ok {
+        return false
+    }
+    if blockTime.Before(time.Now()) {
+	delete(as.ipList, ip.String())
+        return false
+    }
+    return true
+}
+
+func (as *ArrayStorage) UnBlock(ip net.IP) (error) {
+    if as.IsBlocked(ip) {
+        delete(as.ipList, ip.String())
+    }
+    return nil
+}
+
+// RedisStorage implements BlockStorage using a Redis connection.
+type RedisStorage struct {
+    redisHost	string
+}
+
+func (db *RedisStorage) Block(ip net.IP, minutes int) (error) {
+    return nil
+}
+
+func (as *RedisStorage) IsBlocked(ip net.IP) (bool) {
+    return false
+}
+
+func (as *RedisStorage) UnBlock(ip net.IP) (error) {
+    return nil
+}
+
+// BlockManager defines the struct for managing IP addresses.
+type BlockManager struct {
+    storage BlockStorage
+}
+
+func ArrayBlockManager() *BlockManager {
+    var storage BlockStorage
+    storage = &ArrayStorage{
+        ipList: make(map[string]time.Time),
+    }
+    return &BlockManager{
+        storage: storage,
+    }
+}
+
+func RedisBlockManager(host string) *BlockManager {
+    var storage BlockStorage
+    storage = &RedisStorage{
+        redisHost: host,
+    }
+    return &BlockManager{
+        storage: storage,
+    }
+}
+
+func (im *BlockManager) Block(ip net.IP, minutes int) (error) {
+    return im.storage.Block(ip, minutes)
+}
+
+func (im *BlockManager) IsBlocked(ip net.IP) (bool) {
+    return im.storage.IsBlocked(ip)
+}
+
+func (im *BlockManager) UnBlock(ip net.IP) (error) {
+    return im.storage.UnBlock(ip)
+}

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1,4 +1,4 @@
-package traefik_regex_block
+package traefik-regex-block
 
 import (
     "net"

--- a/logger.go
+++ b/logger.go
@@ -1,4 +1,4 @@
-package traefik-regex-block
+package traefik_regex_block
 
 import (
 	"strings"

--- a/logger.go
+++ b/logger.go
@@ -1,4 +1,4 @@
-package traefik_regex_block
+package traefik-regex-block
 
 import (
 	"strings"

--- a/regexblock.go
+++ b/regexblock.go
@@ -1,4 +1,4 @@
-package traefik-regex-block
+package traefik_regex_block
 
 import (
 	"errors"

--- a/regexblock.go
+++ b/regexblock.go
@@ -1,4 +1,4 @@
-package traefik_regex_block
+package traefik-regex-block
 
 import (
 	"errors"

--- a/regexblock.go
+++ b/regexblock.go
@@ -32,10 +32,11 @@ type RegexBlock struct {
 	next              http.Handler
         name              string
 	regexPatterns     []*regexp.Regexp
-	blockDuration     time.Duration
+	blockDuration     int
 	whitelist         []*net.IPNet
 	blockedIPs        map[string]time.Time
 	logger            *pluginLogger
+        blockMgr          *BlockManager
 	mutex             sync.Mutex
 }
 
@@ -65,8 +66,8 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 	}
 
 	// Setup block duration
-	blockDuration := time.Duration(config.BlockDurationMinutes) * time.Minute
-        logger.Info(fmt.Sprintf("Setting block duration as %d minutes.",config.BlockDurationMinutes))
+	blockDuration := config.BlockDurationMinutes
+        logger.Info(fmt.Sprintf("Setting block duration as %d minutes.",blockDuration))
 
 	// Setup list of IP addresses to whitelist
 	whitelist := make([]*net.IPNet, 0)
@@ -86,6 +87,10 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
                 logger.Debug(fmt.Sprintf("Adding whitelist IP %s",ip))
 	}
 
+	// Setup a manager for the block list. Currently only
+	// supports an array. Future plans to support Redis and/or MySQL
+	blockMgr := ArrayBlockManager();
+
 	return &RegexBlock{
 		next:              next,
 		name:              name,
@@ -94,12 +99,14 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		whitelist:         whitelist,
 		blockedIPs:        make(map[string]time.Time),
 		logger:            logger,
+		blockMgr:          blockMgr,
 	}, nil
 }
 
 // ServeHTTP intercepts the request and blocks it if it matches any of the configured regex patterns.
 func (p *RegexBlock) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	ip, _, _ := net.SplitHostPort(req.RemoteAddr)
+	ipNet := net.ParseIP(ip)
         p.logger.Debug(fmt.Sprintf("Testing IP %s.",ip))
 
 	// Check if IP is whitelisted
@@ -112,15 +119,10 @@ func (p *RegexBlock) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	defer p.mutex.Unlock()
 
 	// Check if IP is blocked
-	if blockTime, ok := p.blockedIPs[ip]; ok {
-		if time.Since(blockTime) < p.blockDuration {
-                        p.logger.Debug(fmt.Sprintf("IP %s is still blocked.",ip))
-			rw.WriteHeader(http.StatusForbidden)
-			return
-		} else {
-                        p.logger.Debug(fmt.Sprintf("Removing block for IP %s.",ip))
-			delete(p.blockedIPs, ip) // Unblock the IP if the block time has expired
-		}
+	if p.blockMgr.IsBlocked(ipNet) {
+		p.logger.Debug(fmt.Sprintf("IP %s is still blocked.",ip))
+		rw.WriteHeader(http.StatusForbidden)
+		return
 	}
 
 	// Check if the request matches any regex pattern
@@ -128,7 +130,7 @@ func (p *RegexBlock) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if pattern.MatchString(req.URL.Path) {
 			// Block the IP for the specified duration
                         p.logger.Info(fmt.Sprintf("Setting block for IP %s for requested path %s, based on regex of %s.",ip,req.URL.Path,pattern.String()))
-			p.blockedIPs[ip] = time.Now()
+			p.blockMgr.Block(ipNet,p.blockDuration)
 			rw.WriteHeader(http.StatusNotFound)
 			return
 		}


### PR DESCRIPTION
In the near future, I want to be able to support multiple ways of tracking the IP list. Currently, the plugin only supports an in memory array. Future implementation will attempt to leverage a Redis and/or MySQL backend to track the IPs.

This change sets the framework to support this. A BlockManager can now be implemented by different backends and the calls by the plugin remain the same.

/cc https://github.com/tkreiner/traefik-regex-block/issues/6